### PR TITLE
Use minutes instead of days in pruner

### DIFF
--- a/pruner/prune.sh
+++ b/pruner/prune.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
 
-DELETE_OLDER_THAN_DAYS=$1
+DELETE_OLDER_THAN_MINUTES=$1
 PERIOD_SECONDS="${2:-86400}" # Default: 24 hrs
 
 # Only prune data directory, not the new `hyperliquid_data` directory
 DATA_PATH="/home/hluser/hl/data"
 
 echo "Will prune every $PERIOD_SECONDS seconds"
-echo "Will delete files in data directory older than $DELETE_OLDER_THAN_DAYS days"
+echo "Will delete files in data directory older than $DELETE_OLDER_THAN_MINUTES minutes"
 
 while true; do
     # prune before sleeping
-    echo "Deleting files in data directory older than $DELETE_OLDER_THAN_DAYS days"
-    find "$DATA_PATH" -mindepth 1 -depth -mtime +$DELETE_OLDER_THAN_DAYS -delete
+    echo "Deleting files in data directory older than $DELETE_OLDER_THAN_MINUTES minutes"
+    find "$DATA_PATH" -mindepth 1 -depth -type f -mmin +$DELETE_OLDER_THAN_MINUTES -delete
 
     echo "Sleeping for $PERIOD_SECONDS seconds"
     sleep $PERIOD_SECONDS


### PR DESCRIPTION
Sometimes a day is too long
depending on disk size and speed
of population of these files.

Also adds filter for files.

Relates to https://github.com/ChorusOne/chorus-infrastructure/issues/22253